### PR TITLE
fix: Add new adapter after its successfully connected

### DIFF
--- a/src/methods.js
+++ b/src/methods.js
@@ -35,9 +35,9 @@ module.exports = function (mixinOpts) {
 			this.logger.debug(`Adapter not found for '${hash}'. Create a new adapter instance...`);
 			const adapter = Adapters.resolve(adapterOpts);
 			adapter.init(this);
-			this.adapters.set(hash, { hash, adapter, touched: Date.now() });
 			await this.maintenanceAdapters();
 			await this._connect(adapter, hash, adapterOpts);
+			this.adapters.set(hash, { hash, adapter, touched: Date.now() });
 			this.logger.info(
 				`Adapter '${hash}' connected. Number of adapters:`,
 				this.adapters.size


### PR DESCRIPTION
When a new adapter prematurely added to set, makes the second action invocation fail with error saying `cannot read <adapter function> of undefined`. Because collection object is set only after successful connection.